### PR TITLE
Add ability to run tests by name from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,13 @@ walrus -a YOUR_API_KEY -f test-case-1.yml
 
 walrus -a YOUR_API_KEY -f test-cases/
 ```
+
+### Running existing tests
+
+Sometimes, you may want to run tests in the walrus.ai dashboard from the command line, without storing and maintaining the yml files.
+
+You can call the walrus.ai CLI with a list of test model names:
+
+```bash
+walrus -a YOUR_API_KEY -n 'Test Name 1' 'Test Name 2'
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@walrusai/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sample_test.yml
+++ b/sample_test.yml
@@ -1,0 +1,9 @@
+---
+name: Google Something
+url: 'https://google.com'
+variables:
+  query: 'Sandwich'
+instructions:
+  - "Search for :query:"
+  - "Hit enter"
+  - "Verify results load"

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,20 +12,31 @@ const args = yargs
   .options({
     'api-key': { type: 'string', demandOption: true, alias: 'a' },
     url: { type: 'string', demandOption: false, alias: 'u' },
-    name: { type: 'string', demandOption: false, alias: 'n' },
+    name: { type: 'array', demandOption: false, alias: 'n' },
     revision: { type: 'string', demandOption: false, alias: 'r' },
     instructions: { type: 'array', demandOption: false, alias: 'i' },
     file: { type: 'string', demandOption: false, alias: 'f' },
     verbose: { type: 'boolean', demandOption: false, alias: 'v' },
   })
   .check((argv) => {
-    if (!argv.file && !(argv.instructions && argv.url)) {
-      throw new Error(
-        'You must specify either a file or a directory of tests OR an inline name, url and instructions'
-      );
+    if (argv.file && !argv.name && !argv.instructions && !argv.url) {
+      return true;
     }
 
-    return true;
+    if (argv.name && argv.name.length === 1 && argv.instructions && argv.url && !argv.file) {
+      return true;
+    }
+
+    if (argv.name && argv.name.length > 1 && !argv.instructions && !argv.url && !argv.file) {
+      return true;
+    }
+
+    throw new Error(`
+      You must specify either:
+        - An inline name, url, and instructions
+        - The path to a file or directory of test YML files
+        - A list of test names already created in the Walrus dashboard
+    `);
   }).argv;
 
 if (args.verbose) {
@@ -37,40 +48,43 @@ if (args.verbose) {
 if (args.file && fs.lstatSync(args.file).isDirectory()) {
   glob('/**/*.{yml,yaml}', { root: args.file }, (_, matches) => {
     try {
-      reportTests(matches.map(parseFile), (tests) =>
-        runTests(tests, args['api-key'], args.revision)
-      );
+      reportTests(matches.map(parseFile), (tests) => runTests(tests, args['api-key'], args.revision));
     } catch (e) {
       logger.error(e.message);
     }
   });
 } else if (args.file && fs.lstatSync(args.file).isFile()) {
   try {
-    reportTests([parseFile(args.file)], (tests) =>
-      runTests(tests, args['api-key'], args.revision)
-    );
+    reportTests([parseFile(args.file)], (tests) => runTests(tests, args['api-key'], args.revision));
   } catch (e) {
     logger.error(e.message);
   }
 } else if (args.file) {
   glob(args.file, { root: process.cwd() }, (_, matches) => {
     try {
-      reportTests(matches.map(parseFile), (tests) =>
-        runTests(tests, args['api-key'], args.revision)
-      );
+      reportTests(matches.map(parseFile), (tests) => runTests(tests, args['api-key'], args.revision));
     } catch (e) {
       logger.error(e.message);
     }
   });
 } else {
-  reportTests(
-    [
-      {
-        name: args.name!,
-        url: args.url!,
-        instructions: args.instructions as string[],
-      }
-    ],
-    (tests) => runTests(tests, args['api-key'], args.revision)
-  );
+  if (args.name!.length > 1) {
+    reportTests(
+      args.name!.map((name) => {
+        return { name: name.toString() };
+      }),
+      (tests) => runTests(tests, args['api-key'], args.revision),
+    );
+  } else {
+    reportTests(
+      [
+        {
+          name: args.name![0].toString(),
+          url: args.url!,
+          instructions: args.instructions as string[],
+        },
+      ],
+      (tests) => runTests(tests, args['api-key'], args.revision),
+    );
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const args = yargs
     }
 
     throw new Error(`
-      You must specify either:
+      You must specify only one of:
         - An inline name, url, and instructions
         - The path to a file or directory of test YML files
         - A list of test names already created in the Walrus dashboard

--- a/src/types/walrus_test/index.ts
+++ b/src/types/walrus_test/index.ts
@@ -1,8 +1,8 @@
 export interface WalrusTest {
   gid?: string;
   name: string;
-  url: string;
-  instructions: string[];
+  url?: string;
+  instructions?: string[];
   variables?: Record<string, string>;
   state?: 'pending' | 'completed';
   error?: string;


### PR DESCRIPTION
Adds the ability to pass multiple test names into the CLI, and then invokes those specified tests in walrus **without** requiring local yaml files.